### PR TITLE
Support array of language files in remove_gender_language (e.g. de and de-DE)

### DIFF
--- a/remove_gender_language/classes/Service/RemoveGenderLanguageService.php
+++ b/remove_gender_language/classes/Service/RemoveGenderLanguageService.php
@@ -36,7 +36,7 @@ class RemoveGenderLanguageService
         // Einbinden der Konfigurationsdatei (darin ist die Sprachdatei definiert)
         include (ADMIDIO_PATH . FOLDER_PLUGINS . PLUGIN_FOLDER . PLUGIN_SUBFOLDER . '/config.php');
 
-        $languageFilePath = ADMIDIO_PATH . FOLDER_LANGUAGES . '/' . $languageFileName . '.xml';
+        $languageFileNames = is_array($languageFileName) ? $languageFileName : array($languageFileName);
 
         if (isset($formData['btn_create'])) {
             $mode = 'create';
@@ -55,18 +55,22 @@ class RemoveGenderLanguageService
         switch ($mode) {
 
             case 'create':
-                $languageBackupFilePath = ADMIDIO_PATH . FOLDER_PLUGINS . PLUGIN_FOLDER . PLUGIN_SUBFOLDER . '/' . $languageFileName . '_' . ADMIDIO_VERSION_TEXT . '_' . DATE_NOW . '.xml';
+                foreach ($languageFileNames as $langName) {
+                    $languageFilePath = ADMIDIO_PATH . FOLDER_LANGUAGES . '/' . $langName . '.xml';
+                    if (!file_exists($languageFilePath)) {
+                        continue;
+                    }
+                    $languageBackupFilePath = ADMIDIO_PATH . FOLDER_PLUGINS . PLUGIN_FOLDER . PLUGIN_SUBFOLDER . '/' . $langName . '_' . ADMIDIO_VERSION_TEXT . '_' . DATE_NOW . '.xml';
 
-                try {
-                    FileSystemUtils::copyFile($languageFilePath, $languageBackupFilePath, array(
-                        'overwrite' => true
-                    ));
-                } catch (\RuntimeException $exception) {
-                    $gMessage->show($exception->getMessage());
-                    // => EXIT
-                } catch (\UnexpectedValueException $exception) {
-                    $gMessage->show($exception->getMessage());
-                    // => EXIT
+                    try {
+                        FileSystemUtils::copyFile($languageFilePath, $languageBackupFilePath, array(
+                            'overwrite' => true
+                        ));
+                    } catch (\RuntimeException $exception) {
+                        $gMessage->show($exception->getMessage());
+                    } catch (\UnexpectedValueException $exception) {
+                        $gMessage->show($exception->getMessage());
+                    }
                 }
                 $result = $gL10n->get('PLG_REMOVE_GENDER_LANGUAGE_BACKUP_FILE_CREATED');
                 break;
@@ -75,16 +79,17 @@ class RemoveGenderLanguageService
                 $backupFile = $formData['backup_file'];
                 $backupFilePath = ADMIDIO_PATH . FOLDER_PLUGINS . PLUGIN_FOLDER . PLUGIN_SUBFOLDER . '/' . $backupFile;
 
+                $langName = explode('_', $backupFile)[0];
+                $languageFilePath = ADMIDIO_PATH . FOLDER_LANGUAGES . '/' . $langName . '.xml';
+
                 try {
                     FileSystemUtils::copyFile($backupFilePath, $languageFilePath, array(
                         'overwrite' => true
                     ));
                 } catch (\RuntimeException $exception) {
                     $gMessage->show($exception->getMessage());
-                    // => EXIT
                 } catch (\UnexpectedValueException $exception) {
                     $gMessage->show($exception->getMessage());
-                    // => EXIT
                 }
                 $result = $gL10n->get('PLG_REMOVE_GENDER_LANGUAGE_BACKUP_FILE_RESTORED');
                 break;
@@ -94,13 +99,11 @@ class RemoveGenderLanguageService
                 $backupFilePath = ADMIDIO_PATH . FOLDER_PLUGINS . PLUGIN_FOLDER . PLUGIN_SUBFOLDER . '/' . $backupFile;
 
                 try {
-                    FileSystemUtils::deleteFileIfExists($backupFilePath); // Rückgabe true or false auswerten
+                    FileSystemUtils::deleteFileIfExists($backupFilePath);
                 } catch (\RuntimeException $exception) {
                     $gMessage->show($exception->getMessage());
-                    // => EXIT
                 } catch (\UnexpectedValueException $exception) {
                     $gMessage->show($exception->getMessage());
-                    // => EXIT
                 }
                 $result = $gL10n->get('PLG_REMOVE_GENDER_LANGUAGE_BACKUP_FILE_DELETED');
                 break;
@@ -109,13 +112,21 @@ class RemoveGenderLanguageService
                 include (ADMIDIO_PATH . FOLDER_PLUGINS . PLUGIN_FOLDER . PLUGIN_SUBFOLDER . '/replacements.php');
 
                 $use_errors = libxml_use_internal_errors(true);
-                try {
-                    $xmlLanguageObjects = new \SimpleXMLElement($languageFilePath, 0, true);
-                } catch (Exception $e) {
-                    $result = $gL10n->get('PLG_REMOVE_GENDER_LANGUAGE_REPLACE_ERROR_OPEN');
-                }
+                $anyError = false;
 
-                if ($result !== $gL10n->get('PLG_REMOVE_GENDER_LANGUAGE_REPLACE_ERROR_OPEN')) {
+                foreach ($languageFileNames as $langName) {
+                    $languageFilePath = ADMIDIO_PATH . FOLDER_LANGUAGES . '/' . $langName . '.xml';
+                    if (!file_exists($languageFilePath)) {
+                        continue;
+                    }
+
+                    try {
+                        $xmlLanguageObjects = new \SimpleXMLElement($languageFilePath, 0, true);
+                    } catch (\Exception $e) {
+                        $anyError = true;
+                        continue;
+                    }
+
                     for ($i = 0; $i < count($xmlLanguageObjects->string); $i ++) {
                         $textId = (string) $xmlLanguageObjects->string[$i]['name'];
 
@@ -131,19 +142,19 @@ class RemoveGenderLanguageService
                         }
                     }
 
-                    if (! is_writable($languageFilePath)) {
-                        $result = $gL10n->get('PLG_REMOVE_GENDER_LANGUAGE_REPLACE_ERROR_SAVE');
-                    } else {
-                        if ($xmlLanguageObjects->asXML($languageFilePath) === false) {
-                            $result = $gL10n->get('PLG_REMOVE_GENDER_LANGUAGE_REPLACE_ERROR_SAVE');
-                        } else {
-                            $result = $gL10n->get('PLG_REMOVE_GENDER_LANGUAGE_UPDATED');
-                        }
+                    if (!is_writable($languageFilePath) || $xmlLanguageObjects->asXML($languageFilePath) === false) {
+                        $anyError = true;
                     }
                 }
 
                 libxml_clear_errors();
                 libxml_use_internal_errors($use_errors);
+
+                if ($anyError) {
+                    $result = $gL10n->get('PLG_REMOVE_GENDER_LANGUAGE_REPLACE_ERROR_SAVE');
+                } else {
+                    $result = $gL10n->get('PLG_REMOVE_GENDER_LANGUAGE_UPDATED');
+                }
                 break;
         }
 

--- a/remove_gender_language/config.php
+++ b/remove_gender_language/config.php
@@ -9,6 +9,6 @@
  ***********************************************************************************************
  */
 
-// The name of the language file in which the replacements are performed.
-// e.g. de or en (without .xml)
-$languageFileName =  'de';
+// The name(s) of the language file(s) in which the replacements are performed.
+// e.g. 'de' or array('de', 'de-DE') (without .xml)
+$languageFileName = array('de', 'de-DE');

--- a/remove_gender_language/remove_gender_language.php
+++ b/remove_gender_language/remove_gender_language.php
@@ -73,17 +73,23 @@ try {
                 'mode' => 'save'
             )), $page);
 
-            $languageBackupGlobFilePath = ADMIDIO_PATH . FOLDER_PLUGINS . PLUGIN_FOLDER . PLUGIN_SUBFOLDER . '/' . $languageFileName . '*.xml';
-
-            $backupFiles = glob($languageBackupGlobFilePath);
+            $languageFileNames = is_array($languageFileName) ? $languageFileName : array($languageFileName);
+            $backupFiles = array();
+            foreach ($languageFileNames as $lName) {
+                $files = glob(ADMIDIO_PATH . FOLDER_PLUGINS . PLUGIN_FOLDER . PLUGIN_SUBFOLDER . '/' . $lName . '*.xml');
+                if (is_array($files)) {
+                    $backupFiles = array_merge($backupFiles, $files);
+                }
+            }
             $obsoleteBackupFile = '';
 
             $backupFilesNames = array();
             foreach ($backupFiles as $data) {
-                $fileName = strrchr($data, $languageFileName);
+                $fileName = basename($data);
                 $backupFilesNames[] = $fileName;
 
-                if (ADMIDIO_VERSION_TEXT !== substr($fileName, strlen($languageFileName) + 1, - 15)) {
+                $parts = explode('_', $fileName);
+                if (count($parts) >= 2 && ADMIDIO_VERSION_TEXT !== $parts[1]) {
                     $obsoleteBackupFile = $fileName;
                 }
             }


### PR DESCRIPTION
### Summary
Currently, `remove_gender_language` only processes `de.xml` when `$languageFileName = 'de'`.

However, many Admidio installations use `de-DE` (German - Germany), which loads `/languages/de-DE.xml`. As a result, several key language strings (such as `SYS_ALSO_VISITORS` = "auch Besucher:innen", `SYS_VISITORS`, `SYS_COOKIE_NOTE_DESC`, etc.) are left unreplaced and gendered colons remain visible in the UI.

### Changes
1. Updated `$languageFileName` in `config.php` to accept an array of language codes (`array('de', 'de-DE')`).
2. Updated `RemoveGenderLanguageService.php` to loop over all language files in `$languageFileName` for backup creation, restoration, deletion, and replacement operations.
3. Updated `remove_gender_language.php` backup glob scanning and dropdown selection logic to support multiple language backup files (`de_*.xml`, `de-DE_*.xml`).

### Result
Running the plugin will cleanly remove gendered language regardless of whether the Admidio installation uses `de.xml` or `de-DE.xml`.